### PR TITLE
chore: move inline styles to scss

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -43,38 +43,6 @@
   <router-outlet />
 </div>
 
-<style>
-  .spacer { flex: 1 1 auto; }
-  .topbar { position: sticky; top: 0; z-index: 100; backdrop-filter: saturate(1.2) blur(2px); gap: 12px; }
-  .search { flex: 1; display: flex; align-items: center; gap: 8px; background: var(--mat-sys-surface); border-radius: 999px; padding: 6px 12px; min-width: 320px; }
-  .search input { width: 100%; border: none; outline: none; background: transparent; font: inherit; }
-  .auth { margin-right: 8px; background: var(--mat-sys-surface); border-color: color-mix(in srgb, var(--mat-sys-primary) 30%, transparent); }
-  .categories-bar { position: sticky; top: 64px; z-index: 90; background: linear-gradient(90deg, var(--mat-sys-surface), transparent 98%); }
-  .cat-scroll-wrapper { position: relative; width: 100%; }
-  .cat-scroll { display: flex; gap: 12px; overflow-x: auto; padding: 8px 36px; scrollbar-width: thin; scroll-snap-type: x mandatory; scroll-behavior: smooth; }
-  .cat-chip { display: inline-flex; align-items: center; gap: 8px; padding: 6px 18px 6px 10px; border-radius: 32px; text-decoration: none; background: #fff; color: #1e362b; transition: transform .15s ease, background .2s ease, box-shadow .2s ease; box-shadow: 0 2px 4px rgba(0,0,0,.06); border: 1px solid #e2e8e4; }
-  .cat-chip { scroll-snap-align: start; white-space: nowrap; }
-  .cat-chip:hover { transform: translateY(-1px); background: color-mix(in srgb, var(--mat-sys-secondary-container) 80%, var(--mat-sys-primary) 20%); box-shadow: 0 6px 16px rgba(0,0,0,.12); }
-  .cat-chip img { width: 28px; height: 28px; border-radius: 50%; object-fit: cover; box-shadow: 0 1px 2px rgba(0,0,0,.2); }
-  .cat-chip span { font-weight: 600; letter-spacing: .2px; }
-  /* Force readable category chip text on light background */
-  .cat-chip, .cat-chip span { color: #1e362b !important; }
-  .cat-chip:hover span { color: #1e362b; }
-  .cat-scroll { gap: 16px; padding: 8px 56px; }
-  /* Scroll nav buttons styling for visibility */
-  .cat-nav { width: 40px; height: 40px; display: flex; align-items: center; justify-content: center; border-radius: 50%; background: #ffffffd9; backdrop-filter: blur(4px); border: 1px solid #d6e2db; cursor: pointer; transition: background .2s; }
-  .cat-nav:hover { background: #fff; }
-  .cat-nav mat-icon { color: #0c7c3d; }
-  .fade { display: none; }
-  .brand { font-weight: 600; letter-spacing: .2px; }
-  .container { padding: 20px; max-width: 1200px; margin-inline: auto; }
-  .cat-nav { position: absolute; top: 50%; transform: translateY(-50%); z-index: 1; background: color-mix(in srgb, var(--mat-sys-surface) 88%, transparent); box-shadow: 0 2px 10px rgba(0,0,0,.2); }
-  .cat-nav.left { left: 4px; }
-  .cat-nav.right { right: 4px; }
-  .fade { pointer-events: none; position: absolute; top: 0; bottom: 0; width: 28px; }
-  .fade.left { left: 0; background: linear-gradient(90deg, var(--mat-sys-surface), transparent); }
-  .fade.right { right: 0; background: linear-gradient(270deg, var(--mat-sys-surface), transparent); }
-</style>
 
 <footer class="app-footer">
   <div class="container">

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -1,6 +1,31 @@
 :host { display: block; }
 mat-toolbar { position: sticky; top: 0; z-index: 1000; }
-.container { padding: 16px; }
+.spacer { flex: 1 1 auto; }
+.topbar { position: sticky; top: 0; z-index: 100; backdrop-filter: saturate(1.2) blur(2px); gap: 12px; }
+.search { flex: 1; display: flex; align-items: center; gap: 8px; background: var(--mat-sys-surface); border-radius: 999px; padding: 6px 12px; min-width: 320px; }
+.search input { width: 100%; border: none; outline: none; background: transparent; font: inherit; }
+.auth { margin-right: 8px; background: var(--mat-sys-surface); border-color: color-mix(in srgb, var(--mat-sys-primary) 30%, transparent); }
+.categories-bar { position: sticky; top: 64px; z-index: 90; background: linear-gradient(90deg, var(--mat-sys-surface), transparent 98%); }
+.cat-scroll-wrapper { position: relative; width: 100%; }
+.cat-scroll { display: flex; gap: 16px; overflow-x: auto; padding: 8px 56px; scrollbar-width: thin; scroll-snap-type: x mandatory; scroll-behavior: smooth; }
+.cat-chip { display: inline-flex; align-items: center; gap: 8px; padding: 6px 18px 6px 10px; border-radius: 32px; text-decoration: none; background: #fff; color: #1e362b; transition: transform .15s ease, background .2s ease, box-shadow .2s ease; box-shadow: 0 2px 4px rgba(0,0,0,.06); border: 1px solid #e2e8e4; scroll-snap-align: start; white-space: nowrap; }
+.cat-chip:hover { transform: translateY(-1px); background: color-mix(in srgb, var(--mat-sys-secondary-container) 80%, var(--mat-sys-primary) 20%); box-shadow: 0 6px 16px rgba(0,0,0,.12); }
+.cat-chip img { width: 28px; height: 28px; border-radius: 50%; object-fit: cover; box-shadow: 0 1px 2px rgba(0,0,0,.2); }
+.cat-chip span { font-weight: 600; letter-spacing: .2px; }
+/* Force readable category chip text on light background */
+.cat-chip, .cat-chip span { color: #1e362b !important; }
+.cat-chip:hover span { color: #1e362b; }
+/* Scroll nav buttons styling for visibility */
+.cat-nav { width: 40px; height: 40px; display: flex; align-items: center; justify-content: center; border-radius: 50%; backdrop-filter: blur(4px); border: 1px solid #d6e2db; cursor: pointer; transition: background .2s; position: absolute; top: 50%; transform: translateY(-50%); z-index: 1; background: color-mix(in srgb, var(--mat-sys-surface) 88%, transparent); box-shadow: 0 2px 10px rgba(0,0,0,.2); }
+.cat-nav:hover { background: #fff; }
+.cat-nav mat-icon { color: #0c7c3d; }
+.cat-nav.left { left: 4px; }
+.cat-nav.right { right: 4px; }
+.fade { display: none; pointer-events: none; position: absolute; top: 0; bottom: 0; width: 28px; }
+.fade.left { left: 0; background: linear-gradient(90deg, var(--mat-sys-surface), transparent); }
+.fade.right { right: 0; background: linear-gradient(270deg, var(--mat-sys-surface), transparent); }
+.brand { font-weight: 600; letter-spacing: .2px; }
+.container { padding: 20px; max-width: 1200px; margin-inline: auto; }
 @media (max-width: 768px) {
-	.container { padding: 12px; }
+  .container { padding: 12px; }
 }


### PR DESCRIPTION
## Summary
- extract inline app styles into dedicated `app.scss` file
- keep component configured to load `app.scss` via `styleUrl`
- maintain toolbar and category styling across breakpoints

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `npm run build` *(fails: 403 fetching Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689a6bb06338832dae6a2b0b59a59ed1