### PR TITLE
Move category mobile styles into component

### DIFF
--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -175,6 +175,24 @@
   }
 }
 
+@media (max-width: 520px) {
+  .cat-scroll {
+    padding: 6px 44px;
+    gap: 12px;
+  }
+
+  .cat-chip {
+    padding: 4px 14px 4px 8px;
+    font-size: .75rem;
+  }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+  .cat-scroll {
+    padding: 4px 40px;
+  }
+}
+
 @media (min-width: 768px) {
   .cat-scroll {
     gap: 16px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -105,22 +105,19 @@ app-footer { display: block; }
 }
 
 @media (max-width: 520px) {
-	.hero { border-radius: 20px; }
-	.hero-track .slide-content { padding: 22px 18px !important; min-height: 180px; }
-	.cat-scroll { padding: 6px 44px !important; gap: 12px !important; }
-	.cat-chip { padding: 4px 14px 4px 8px; font-size: .75rem; }
-	.product-card mat-card-title { font-size: .78rem; line-height: 1.2; }
-	.product-card mat-card-content p { font-size: .7rem; }
-	.app-footer .bottom { flex-direction: column; align-items: flex-start; }
-	/* Force 2 columns product grid for better density */
-	.products { grid-template-columns: repeat(2,1fr) !important; }
-	.product-card { margin: 0; }
+        .hero { border-radius: 20px; }
+        .hero-track .slide-content { padding: 22px 18px !important; min-height: 180px; }
+        .product-card mat-card-title { font-size: .78rem; line-height: 1.2; }
+        .product-card mat-card-content p { font-size: .7rem; }
+        .app-footer .bottom { flex-direction: column; align-items: flex-start; }
+        /* Force 2 columns product grid for better density */
+        .products { grid-template-columns: repeat(2,1fr) !important; }
+        .product-card { margin: 0; }
 }
 
 /* Fine-grained landscape phone adjustments */
 @media (max-height: 520px) and (orientation: landscape) {
-	mat-toolbar.topbar { padding: 0 8px; }
-	.cat-scroll { padding: 4px 40px !important; }
+        mat-toolbar.topbar { padding: 0 8px; }
 }
 
 /* Title/description clamping for cards */


### PR DESCRIPTION
## Summary
- scope category bar responsive styles within `app.scss`
- remove `!important` flags now that styles live with the component

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689a8e431544832d86d6330c75e3ac6f